### PR TITLE
Reject classic movies with invalid release months

### DIFF
--- a/src/command_file.cpp
+++ b/src/command_file.cpp
@@ -169,12 +169,20 @@ DVD CommandFile::parseDVD(const std::string& line)
     }
     else if (std::regex_search(line, classic_match, classic_pattern))
     {
+        int releaseMonth = stoi(classic_match[1]);
+
+        // Check for a valid movie release month.
+        if (releaseMonth < 1 || 12 < releaseMonth)
+        {
+            throw std::runtime_error("Invalid dvd release month");
+        }
+
         return DVD{std::shared_ptr<Movie>{new ClassicMovie(
             "classic",              // .genre
             "",                     // .director
             "",                     // .title
             stoi(classic_match[2]), // .releaseYear
-            stoi(classic_match[1]), // .releaseMonth
+            releaseMonth,           // .releaseMonth
             classic_match[3]        // .actor
         )}};
     }

--- a/src/inventory_file.cpp
+++ b/src/inventory_file.cpp
@@ -90,13 +90,25 @@ void InventoryFile::parseFile()
         }
         else if (std::regex_search(line, classic_match, classic_pattern))
         {
+            int releaseMonth = stoi(classic_match[5]);
+
+            // Check for an invalid release month.
+            if (releaseMonth < 1 || 12 < releaseMonth)
+            {
+                error_list.emplace_back(
+                    std::make_shared<std::runtime_error>(
+                        "[Invalid inventory item] " + line
+                ));
+                continue;
+            }
+
             file_inventory.addStock(
                 DVD(std::shared_ptr<Movie>{new ClassicMovie(
                     "classic",              // .genre
                     classic_match[2],       // .director
                     classic_match[3],       // .title
                     stoi(classic_match[6]), // .releaseYear
-                    stoi(classic_match[5]), // .releaseMonth
+                    releaseMonth, 	    // .releaseMonth
                     classic_match[4]        // .actor
                 )}),
                 stoi(classic_match[1])      // .quantity


### PR DESCRIPTION
Currently, any 2 digit month would be accepted by the parser for classic movies. This includes values of 0 and values greater than 12, which do not correspond to valid months. This commit restricts valid input months to the numbers 1-12 (inclusive) so that each input values relates to a valid calendar month.